### PR TITLE
Add a STU_TARGETS variable to the environment of each command.

### DIFF
--- a/execution.hh
+++ b/execution.hh
@@ -2945,7 +2945,8 @@ Proceed File_Execution::execute(shared_ptr <const Dep> dep_this)
 				 rule->place_param_targets[rule->redirect_index]
 				 ->place_name.unparametrized(),
 				 rule->filename.unparametrized(),
-				 rule->command->place); 
+				 rule->command->place,
+				 targets);
 		}
 
 		assert(pid != 0 && pid != 1); 


### PR DESCRIPTION
Every target, separated by newline if there is more than one target

In almost every rule I make, I manually set a `target` environment variable, so it would be convenient if `stu` did it by default. I tend to use that for many purposes, for example I have `mkdir -p "${dirname "$target"}"` also, and I can easily just copy and paste that line between targets