### PR TITLE
Clarify persistent dependencies in manpage

### DIFF
--- a/man/stu.1
+++ b/man/stu.1
@@ -557,7 +557,8 @@ thus their command do not create files.
     -p NAME   A persistent dependency
 
 Stu will only check whether the dependency exists, but not its
-modification time.  This is mostly useful for directories, as the
+modification time for determining whether the target has to be rebuilt.
+This is mostly useful for directories, as the
 modification time of directories is updated whenever files are added or
 removed in the directory.
 

--- a/man/stu.1.in
+++ b/man/stu.1.in
@@ -556,7 +556,8 @@ thus their command do not create files.
     -p NAME   A persistent dependency
 
 Stu will only check whether the dependency exists, but not its
-modification time.  This is mostly useful for directories, as the
+modification time for determining whether the target has to be rebuilt.
+This is mostly useful for directories, as the
 modification time of directories is updated whenever files are added or
 removed in the directory.
 


### PR DESCRIPTION
The modification time of a persistent dependency will not be checked for determining whether the target has to be rebuilt. However, it will be checked to determine whether itself has to be rebuilt.

For instance, with the following `main.stu` and `gen-data.sh`, when building `result`, the modification time of `data` will be checked, and if it is older than `gen-data.sh` , `data` will be rebuilt.

```sh
% version 2.6
@all: result;

>result: -p data
{
    cat data
}

>data: gen-data.sh
{
    bash gen-data.sh
}
```

```sh
#!/bin/sh
echo "This is data"
```